### PR TITLE
Update lunar.md

### DIFF
--- a/src/guide/functional/lunar.md
+++ b/src/guide/functional/lunar.md
@@ -165,6 +165,6 @@ lunisolar().lunar.leapMonthIsBig
 /**
  * @return {Date}
  */
-lunisolar().lunar.getLunarNewYearDay()
+lunisolar.Lunar.getLunarNewYearDay()
 ```
 


### PR DESCRIPTION
the `getLunarNewYearDay()` method is not exist lunisolar().lunar getters